### PR TITLE
Add installation  for Gazebo Harmonic in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,16 @@ RUN cd ~ && \
     git clone https://github.com/ros2/examples src/examples -b humble
     #colcon build --symlink-install
 
+# Install tools for Gazebo Harmonic
+RUN apt-get update && \
+    apt-get install -y curl lsb-release gnupg
+
+# Install Gazebo Harmonic
+RUN curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y gz-harmonic
+
 # Source the setup.bash to ensure environment variables are set correctly
 # SHELL ["/bin/bash", "-c", "source ~/.bashrc"]
 


### PR DESCRIPTION
I had to fork it for some reason. Hoping this allows it to go across.

Pretty simple, added the binary installation steps to the end of the Dockerfile. Builds and runs on my device. Check my notebook for the command.

Going to work on getting it to the GHCR soon.